### PR TITLE
Update Nuxt configuration and dependencies for Supabase integration

### DIFF
--- a/composables/useConversationManagement.ts
+++ b/composables/useConversationManagement.ts
@@ -1,4 +1,3 @@
-import { useSupabaseClient, useSupabaseUser } from '#imports';
 import type { Database } from '~/types/database.types';
 
 type Conversation = Database['public']['Tables']['conversations']['Insert'];

--- a/composables/useConversationSubscriptions.ts
+++ b/composables/useConversationSubscriptions.ts
@@ -1,4 +1,3 @@
-import { useSupabaseClient, useToast } from '#imports';
 import type { Database } from '~/types/database.types';
 import { useConversationsStore } from '~/stores/inbox/conversations';
 import { useMessagesStore } from '~/stores/inbox/messages';

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -53,10 +53,18 @@ export default defineNuxtConfig({
     pageTransition: { name: 'page', mode: 'out-in' },
   },
   supabase: {
+    url: process.env.SUPABASE_URL,
+    key: process.env.SUPABASE_KEY,
     redirectOptions: {
       login: '/login',
       callback: '/confirm',
       exclude: ['/signup', '/login'],
+    },
+  },
+  runtimeConfig: {
+    public: {
+      supabaseUrl: process.env.SUPABASE_URL,
+      supabaseKey: process.env.SUPABASE_KEY,
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@nuxt/fonts": "0.11.4",
     "@nuxt/icon": "1.13.0",
     "@nuxt/ui": "3.1.2",
+    "@pinia/nuxt": "^0.5.1",
     "@tailwindcss/vite": "^4.1.7",
     "eslint": "^9.0.0",
     "nuxt": "^3.17.4",
@@ -28,7 +29,6 @@
   "devDependencies": {
     "@iconify-json/lucide": "^1.2.44",
     "@nuxtjs/supabase": "^1.5.1",
-    "@pinia/nuxt": "^0.11.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.0",
     "prettier": "^3.5.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@nuxt/ui':
         specifier: 3.1.2
         version: 3.1.2(@babel/parser@7.27.2)(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.6.1)(jwt-decode@4.0.0)(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(vue-router@4.5.1(vue@3.5.14(typescript@5.8.3)))(vue@3.5.14(typescript@5.8.3))(zod@3.25.20)
+      '@pinia/nuxt':
+        specifier: ^0.5.1
+        version: 0.5.5(magicast@0.3.5)(typescript@5.8.3)(vue@3.5.14(typescript@5.8.3))
       '@tailwindcss/vite':
         specifier: ^4.1.7
         version: 4.1.7(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))
@@ -54,9 +57,6 @@ importers:
       '@nuxtjs/supabase':
         specifier: ^1.5.1
         version: 1.5.1
-      '@pinia/nuxt':
-        specifier: ^0.11.0
-        version: 0.11.0(magicast@0.3.5)(pinia@3.0.2(typescript@5.8.3)(vue@3.5.14(typescript@5.8.3)))
       eslint-config-prettier:
         specifier: ^10.1.5
         version: 10.1.5(eslint@9.27.0(jiti@2.4.2))
@@ -908,10 +908,8 @@ packages:
     resolution: {integrity: sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==}
     engines: {node: '>= 10.0.0'}
 
-  '@pinia/nuxt@0.11.0':
-    resolution: {integrity: sha512-QGFlUAkeVAhPCTXacrtNP4ti24sGEleVzmxcTALY9IkS6U5OUox7vmNL1pkqBeW39oSNq/UC5m40ofDEPHB1fg==}
-    peerDependencies:
-      pinia: ^3.0.2
+  '@pinia/nuxt@0.5.5':
+    resolution: {integrity: sha512-wjxS7YqIesh4OLK+qE3ZjhdOJ5pYZQ+VlEmZNtTwzQn1Kavei/khovx7mzXVXNA/mvSPXVhb9xBzhyS3XMURtw==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1532,9 +1530,6 @@ packages:
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
-
-  '@vue/devtools-api@7.7.6':
-    resolution: {integrity: sha512-b2Xx0KvXZObePpXPYHvBRRJLDQn5nhKjXh7vUhMEtWxz1AYNFOVIsh5+HLP8xDGL7sy+Q7hXeUxPHB/KgbtsPw==}
 
   '@vue/devtools-core@7.7.6':
     resolution: {integrity: sha512-ghVX3zjKPtSHu94Xs03giRIeIWlb9M+gvDRVpIZ/cRIxKHdW6HE/sm1PT3rUYS3aV92CazirT93ne+7IOvGUWg==}
@@ -3771,8 +3766,8 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
-  pinia@3.0.2:
-    resolution: {integrity: sha512-sH2JK3wNY809JOeiiURUR0wehJ9/gd9qFN2Y828jCbxEzKEmEt0pzCXwqiSTfuRsK9vQsOflSdnbdBOGrhtn+g==}
+  pinia@2.3.1:
+    resolution: {integrity: sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==}
     peerDependencies:
       typescript: '>=4.4.4'
       vue: ^2.7.0 || ^3.5.11
@@ -6230,12 +6225,15 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.1
       '@parcel/watcher-win32-x64': 2.5.1
 
-  '@pinia/nuxt@0.11.0(magicast@0.3.5)(pinia@3.0.2(typescript@5.8.3)(vue@3.5.14(typescript@5.8.3)))':
+  '@pinia/nuxt@0.5.5(magicast@0.3.5)(typescript@5.8.3)(vue@3.5.14(typescript@5.8.3))':
     dependencies:
       '@nuxt/kit': 3.17.4(magicast@0.3.5)
-      pinia: 3.0.2(typescript@5.8.3)(vue@3.5.14(typescript@5.8.3))
+      pinia: 2.3.1(typescript@5.8.3)(vue@3.5.14(typescript@5.8.3))
     transitivePeerDependencies:
+      - '@vue/composition-api'
       - magicast
+      - typescript
+      - vue
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6867,10 +6865,6 @@ snapshots:
       '@vue/shared': 3.5.14
 
   '@vue/devtools-api@6.6.4': {}
-
-  '@vue/devtools-api@7.7.6':
-    dependencies:
-      '@vue/devtools-kit': 7.7.6
 
   '@vue/devtools-core@7.7.6(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.8.0))(vue@3.5.14(typescript@5.8.3))':
     dependencies:
@@ -9337,12 +9331,15 @@ snapshots:
 
   picomatch@4.0.2: {}
 
-  pinia@3.0.2(typescript@5.8.3)(vue@3.5.14(typescript@5.8.3)):
+  pinia@2.3.1(typescript@5.8.3)(vue@3.5.14(typescript@5.8.3)):
     dependencies:
-      '@vue/devtools-api': 7.7.6
+      '@vue/devtools-api': 6.6.4
       vue: 3.5.14(typescript@5.8.3)
+      vue-demi: 0.14.10(vue@3.5.14(typescript@5.8.3))
     optionalDependencies:
       typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   pkg-types@1.3.1:
     dependencies:

--- a/stores/profile.ts
+++ b/stores/profile.ts
@@ -24,6 +24,8 @@ export const useProfileStore = defineStore('profile', () => {
     }
 
     loading.value = true;
+    error.value = null;
+    
     try {
       const { data, error: fetchError } = await supabase
         .from('user_profiles')
@@ -33,11 +35,13 @@ export const useProfileStore = defineStore('profile', () => {
 
       if (fetchError) {
         error.value = fetchError.message;
+        profile.value = null;
       } else {
         profile.value = data;
       }
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'An unknown error occurred';
+      profile.value = null;
     } finally {
       loading.value = false;
     }
@@ -82,7 +86,7 @@ export const useProfileStore = defineStore('profile', () => {
   // Watch for user changes and fetch profile
   watch(
     () => useSupabaseUser().value,
-    newUser => {
+    (newUser) => {
       if (newUser) {
         fetchProfile();
       } else {


### PR DESCRIPTION
- Added Supabase URL and key to the Nuxt configuration for improved environment management.
- Updated `@pinia/nuxt` dependency to version 0.5.1 in `package.json` and adjusted related entries in `pnpm-lock.yaml`.
- Refactored conversation management composables to remove unused imports, enhancing code clarity.
- Enhanced error handling in the profile store to reset profile state on errors.