### PR TITLE
Add new favicon configurations for Android devices

### DIFF
--- a/config/seo.ts
+++ b/config/seo.ts
@@ -44,6 +44,18 @@ export const seoConfig = {
       href: '/favicon/site.webmanifest',
     },
     {
+      rel: 'icon',
+      type: 'image/png',
+      sizes: '192x192',
+      href: '/favicon/android-chrome-192x192.png',
+    },
+    {
+      rel: 'icon',
+      type: 'image/png',
+      sizes: '512x512',
+      href: '/favicon/android-chrome-512x512.png',
+    },
+    {
       rel: 'canonical',
       href: 'https://linkup.com'
     }

--- a/public/android-chrome-192x192.png
+++ b/public/android-chrome-192x192.png
@@ -1,0 +1,1 @@
+favicon/android-chrome-192x192.png

--- a/public/android-chrome-512x512.png
+++ b/public/android-chrome-512x512.png
@@ -1,0 +1,1 @@
+favicon/android-chrome-512x512.png


### PR DESCRIPTION
- Updated `seo.ts` to include new favicon links for Android devices with specified sizes (192x192 and 512x512).
- Added corresponding favicon image files for Android devices in the public directory.

This enhances the branding and visual identity of the application on Android platforms.